### PR TITLE
Add flexible button position and fullscreen hide

### DIFF
--- a/content.js
+++ b/content.js
@@ -11,6 +11,7 @@ class YouTubeTranscriptExtractor {
     this.setupMessageListener();
     await this.loadButtonSettings();
     this.setupStorageListener();
+    this.setupFullscreenListener();
     this.waitForPageLoad();
     this.setupNavigationListener();
   }
@@ -73,12 +74,30 @@ class YouTubeTranscriptExtractor {
     });
   }
 
+  setupFullscreenListener() {
+    document.addEventListener('fullscreenchange', () => {
+      const btn = document.getElementById('transcript-summary-btn');
+      if (!btn) return;
+      if (document.fullscreenElement) {
+        btn.style.display = 'none';
+      } else {
+        btn.style.display = 'flex';
+      }
+    });
+  }
+
   getPositionStyles() {
     switch (this.buttonPosition) {
       case 'top-right':
         return 'top: 20px !important; right: 20px !important;';
+      case 'top-left':
+        return 'top: 20px !important; left: 20px !important;';
       case 'bottom-right':
         return 'bottom: 20px !important; right: 20px !important;';
+      case 'bottom-left':
+        return 'bottom: 20px !important; left: 20px !important;';
+      case 'middle-left':
+        return 'top: 80px !important; left: 20px !important;';
       case 'middle-right':
       default:
         return 'top: 80px !important; right: 20px !important;';

--- a/popup.html
+++ b/popup.html
@@ -86,6 +86,9 @@
         <option value="top-right">Prawy górny róg</option>
         <option value="middle-right">Niżej po prawej</option>
         <option value="bottom-right">Prawy dolny róg</option>
+        <option value="top-left">Lewy górny róg</option>
+        <option value="middle-left">Niżej po lewej</option>
+        <option value="bottom-left">Lewy dolny róg</option>
       </select>
     </div>
     <div class="form-group">

--- a/styles.css
+++ b/styles.css
@@ -23,8 +23,6 @@
 /* Style dla różnych rozdzielczości */
 @media (max-width: 768px) {
   #transcript-summary-btn {
-    top: 10px !important;
-    right: 10px !important;
     padding: 10px 16px !important;
     font-size: 13px !important;
   }
@@ -32,8 +30,6 @@
 
 @media (max-width: 480px) {
   #transcript-summary-btn {
-    top: 5px !important;
-    right: 5px !important;
     padding: 8px 12px !important;
     font-size: 12px !important;
     min-width: 100px !important;


### PR DESCRIPTION
## Summary
- add fullscreen listener to hide Analyze button when the video is in fullscreen mode
- support more button positions (left/right) and update popup options
- simplify responsive CSS so position isn't overridden on small screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68615e2998d08325ab0f812e08b19f8c