### PR TITLE
Fix subtitle format parameter

### DIFF
--- a/content.js
+++ b/content.js
@@ -821,7 +821,13 @@ class YouTubeTranscriptExtractor {
 
       if (!selectedCaption.baseUrl) return null;
 
-      const response = await fetch(selectedCaption.baseUrl);
+      // Ensure the caption URL requests VTT format if no format is specified
+      const captionUrl = new URL(selectedCaption.baseUrl);
+      if (!captionUrl.searchParams.has('fmt')) {
+        captionUrl.searchParams.set('fmt', 'vtt');
+      }
+
+      const response = await fetch(captionUrl.toString());
       if (!response.ok) {
         console.error('Błąd pobierania transkrypcji:', response.status);
         return null;


### PR DESCRIPTION
## Summary
- ensure caption URL defaults to VTT format

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68616e49e6288325850e0d6f9be1d8a6